### PR TITLE
Fixed ErrorException for incompatible __doRequest

### DIFF
--- a/ET_Client.php
+++ b/ET_Client.php
@@ -173,7 +173,7 @@ class ET_Client extends SoapClient {
 		return curl_getinfo($curl, CURLINFO_FILETIME);
 	}
 				
-	function __doRequest($request, $location, $saction, $version) {
+	function __doRequest($request, $location, $saction, $version, $one_way=null) {
 		$doc = new DOMDocument();
 		$doc->loadXML($request);
 		


### PR DESCRIPTION
```
ErrorException Object
(
    [message:protected] => Declaration of ET_Client::__doRequest() should be compatible with SoapClient::__doRequest($request, $location, $action, $version, $one_way = NULL)
    [string:Exception:private] =>
    [code:protected] => 0
    [file:protected] => /home/mark/code/parkwhiz.com/app/ET_Client.php
    [line:protected] => 465
    [trace:Exception:private] => Array
        (
            [0] => Array
                (
                    [function] => fatal_error_checker
                    [class] => JMVC
                    [type] => ::
                    [args] => Array
                        (
                        )

                )

        )

    [previous:Exception:private] =>
    [severity:protected] => 2048
)
```
