### PR TITLE
Check to see if the config file exists

### DIFF
--- a/ET_Client.php
+++ b/ET_Client.php
@@ -4,13 +4,17 @@ require('JWT.php');
 
 class ET_Client extends SoapClient {
 	public $packageName, $packageFolders, $parentFolders;
-	private $wsdlLoc, $debugSOAP, $lastHTTPCode, $clientId, 
-			$clientSecret, $appsignature, $endpoint, 
+	private $wsdlLoc, $debugSOAP, $lastHTTPCode, $clientId,
+			$clientSecret, $appsignature, $endpoint,
 			$tenantTokens, $tenantKey;
-		
-	function __construct($getWSDL = false, $debug = false, $params = null) {	
+
+	function __construct($getWSDL = false, $debug = false, $params = null) {
 		$tenantTokens = array();
-		$config = @include 'config.php';
+		$config = false;
+
+		if (file_exists(realpath(__DIR__ . "/config.php")))
+			$config = include 'config.php';
+
 		if ($config){
 			$this->wsdlLoc = $config['defaultwsdl'];
 			$this->clientId = $config['clientid'];
@@ -23,15 +27,15 @@ class ET_Client extends SoapClient {
 			if ($params && array_key_exists('clientsecret', $params)){$this->clientSecret = $params['clientsecret'];}
 			if ($params && array_key_exists('appsignature', $params)){$this->appsignature = $params['appsignature'];}
 		}
-		
+
 		$this->debugSOAP = $debug;
-		
+
 		if (!property_exists($this,'clientId') || is_null($this->clientId) || !property_exists($this,'clientSecret') || is_null($this->clientSecret)){
 			throw new Exception('clientid or clientsecret is null: Must be provided in config file or passed when instantiating ET_Client');
 		}
-		
+
 		if ($getWSDL){$this->CreateWSDL($this->wsdlLoc);}
-		
+
 		if ($params && array_key_exists('jwt', $params)){
 			if (!property_exists($this,'appsignature') || is_null($this->appsignature)){
 				throw new Exception('Unable to utilize JWT for SSO without appsignature: Must be provided in config file or passed when instantiating ET_Client');
@@ -43,28 +47,28 @@ class ET_Client extends SoapClient {
 			$this->setInternalAuthToken($this->tenantKey, $decodedJWT->request->user->internalOauthToken);
 			$this->setRefreshToken($this->tenantKey, $decodedJWT->request->user->refreshToken);
 			$this->packageName = $decodedJWT->request->application->package;
-		}		
+		}
 		$this->refreshToken();
 
 		try {
 			$url = "https://www.exacttargetapis.com/platform/v1/endpoints/soap?access_token=".$this->getAuthToken($this->tenantKey);
-			$endpointResponse = restGet($url);			
-			$endpointObject = json_decode($endpointResponse->body);			
-			if ($endpointResponse && property_exists($endpointObject,"url")){		
-				$this->endpoint = $endpointObject->url;			
+			$endpointResponse = restGet($url);
+			$endpointObject = json_decode($endpointResponse->body);
+			if ($endpointResponse && property_exists($endpointObject,"url")){
+				$this->endpoint = $endpointObject->url;
 			} else {
-				throw new Exception('Unable to determine stack using /platform/v1/endpoints/:'.$endpointResponse->body);			
+				throw new Exception('Unable to determine stack using /platform/v1/endpoints/:'.$endpointResponse->body);
 			}
 			} catch (Exception $e) {
 			throw new Exception('Unable to determine stack using /platform/v1/endpoints/: '.$e->getMessage());
-		} 		
+		}
 		parent::__construct($this->LocalWsdlPath(), array('trace'=>1, 'exceptions'=>0));
 		parent::__setLocation($this->endpoint);
 	}
-	
+
 	function refreshToken($forceRefresh = false) {
 		if (property_exists($this, "sdl") && $this->sdl == 0){
-			parent::__construct($this->LocalWsdlPath(), array('trace'=>1, 'exceptions'=>0));	
+			parent::__construct($this->LocalWsdlPath(), array('trace'=>1, 'exceptions'=>0));
 		}
 		try {
 			$currentTime = new DateTime();
@@ -76,10 +80,10 @@ class ET_Client extends SoapClient {
 			}
 
 			if (is_null($this->getAuthToken($this->tenantKey)) || ($timeDiff < 5) || $forceRefresh  ){
-				$url = $this->tenantKey == null 
+				$url = $this->tenantKey == null
 						? "https://auth.exacttargetapis.com/v1/requestToken?legacy=1"
 						: "https://www.exacttargetapis.com/provisioning/v1/tenants/{$this->tenantKey}/requestToken?legacy=1";
-				$jsonRequest = new stdClass(); 
+				$jsonRequest = new stdClass();
 				$jsonRequest->clientId = $this->clientId;
 				$jsonRequest->clientSecret = $this->clientSecret;
 				$jsonRequest->accessType = "offline";
@@ -88,76 +92,76 @@ class ET_Client extends SoapClient {
 				}
 				$authResponse = restPost($url, json_encode($jsonRequest));
 				$authObject = json_decode($authResponse->body);
-				
-				if ($authResponse && property_exists($authObject,"accessToken")){		
-					
+
+				if ($authResponse && property_exists($authObject,"accessToken")){
+
 					$dv = new DateInterval('PT'.$authObject->expiresIn.'S');
 					$newexpTime = new DateTime();
 					$this->setAuthToken($this->tenantKey, $authObject->accessToken, $newexpTime->add($dv));
-					$this->setInternalAuthToken($this->tenantKey, $authObject->legacyToken);					
+					$this->setInternalAuthToken($this->tenantKey, $authObject->legacyToken);
 					if (property_exists($authObject,'refreshToken')){
 						$this->setRefreshToken($this->tenantKey, $authObject->refreshToken);
 					}
 				} else {
-					throw new Exception('Unable to validate App Keys(ClientID/ClientSecret) provided, requestToken response:'.$authResponse->body );			
-				}				
+					throw new Exception('Unable to validate App Keys(ClientID/ClientSecret) provided, requestToken response:'.$authResponse->body );
+				}
 			}
 		} catch (Exception $e) {
 			throw new Exception('Unable to validate App Keys(ClientID/ClientSecret) provided.: '.$e->getMessage());
 		}
 	}
-	
+
 	function __getLastResponseHTTPCode(){
 
-		return $this->lastHTTPCode;		
+		return $this->lastHTTPCode;
 	}
-	
+
 	function CreateWSDL($wsdlLoc) {
-		
+
 		try{
 			$getNewWSDL = true;
-			
+
 			$remoteTS = $this->GetLastModifiedDate($wsdlLoc);
-			
+
 			if (file_exists($this->LocalWsdlPath())){
 				$localTS = filemtime($this->LocalWsdlPath());
-				if ($remoteTS <= $localTS) 
+				if ($remoteTS <= $localTS)
 				{
 					$getNewWSDL = false;
 				}
 			}
-			
+
 			if ($getNewWSDL){
 				$newWSDL = file_get_contents($wsdlLoc);
 				file_put_contents($this->LocalWsdlPath(), $newWSDL);
-			}	
+			}
 		}
 		catch (Exception $e) {
 			throw new Exception('Unable to store local copy of WSDL file'."\n");
 		}
 	}
-	
+
 	function LocalWsdlPath()
 	{
 		$wsdlName = 'ExactTargetWSDL.xml';
 		$tmpPath = '';
-		
+
 		// if open_basedir is set then we cannot trust sys_get_temp_dir()
 		// see http://php.net/manual/en/function.sys-get-temp-dir.php#97044
 		if ('' === ini_get('open_basedir')) {
 			$tmpPath = sys_get_temp_dir();
-			
+
 			// sys_get_temp_dir() does not return a trailing slash on all OS's
 			// see http://php.net/manual/en/function.sys-get-temp-dir.php#80690
 			if ('/' !== substr($tmpPath, -1)) {
 				$tmpPath .= '/';
 			}
 		}
-		
+
 		return "{$tmpPath}{$wsdlName}";
-		
+
 	}
-	
+
 	function GetLastModifiedDate($remotepath) {
 		$curl = curl_init($remotepath);
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
@@ -165,29 +169,29 @@ class ET_Client extends SoapClient {
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_FILETIME, true);
 		$result = curl_exec($curl);
-		
+
 		if ($result === false) {
-			die (curl_error($curl)); 
+			die (curl_error($curl));
 		}
-		
+
 		return curl_getinfo($curl, CURLINFO_FILETIME);
 	}
-				
+
 	function __doRequest($request, $location, $saction, $version, $one_way=null) {
 		$doc = new DOMDocument();
 		$doc->loadXML($request);
-		
+
 		$objWSSE = new WSSESoap($doc);
 		$objWSSE->addUserToken("*", "*", FALSE);
 		$objWSSE->addOAuth($this->getInternalAuthToken($this->tenantKey));
-				
+
 		$content = utf8_encode($objWSSE->saveXML());
-		$content_length = strlen($content); 
+		$content_length = strlen($content);
 		if ($this->debugSOAP){
 			error_log ('FuelSDK SOAP Request: ');
 			error_log (str_replace($this->getInternalAuthToken($this->tenantKey),"REMOVED",$content));
 		}
-		
+
 		$headers = array("Content-Type: text/xml","SOAPAction: ".$saction, "User-Agent: ".getSDKVersion());
 
 		$ch = curl_init();
@@ -199,21 +203,21 @@ class ET_Client extends SoapClient {
 		curl_setopt($ch, CURLOPT_USERAGENT, "FuelSDK-PHP-v0.9");
 		$output = curl_exec($ch);
 		$this->lastHTTPCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch); 
-						
+		curl_close($ch);
+
 		return $output;
 	}
-	
+
 	public function getAuthToken($tenantKey = null) {
 		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;
 		if ($this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
-		}		
-		return isset($this->tenantTokens[$tenantKey]['authToken']) 
+		}
+		return isset($this->tenantTokens[$tenantKey]['authToken'])
 			? $this->tenantTokens[$tenantKey]['authToken']
 			: null;
 	}
-	
+
 	function setAuthToken($tenantKey, $authToken, $authTokenExpiration) {
 		if ($this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
@@ -221,7 +225,7 @@ class ET_Client extends SoapClient {
 		$this->tenantTokens[$tenantKey]['authToken'] = $authToken;
 		$this->tenantTokens[$tenantKey]['authTokenExpiration'] = $authTokenExpiration;
 	}
-	
+
 	function getAuthTokenExpiration($tenantKey) {
 		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;
 		if ($this->tenantTokens[$tenantKey] == null) {
@@ -233,7 +237,7 @@ class ET_Client extends SoapClient {
 	}
 
 	function getInternalAuthToken($tenantKey) {
-		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;	
+		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;
 		if ($this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}
@@ -245,28 +249,28 @@ class ET_Client extends SoapClient {
 	function setInternalAuthToken($tenantKey, $internalAuthToken) {
 		if ($this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
-		}	
+		}
 		$this->tenantTokens[$tenantKey]['internalAuthToken'] = $internalAuthToken;
 	}
-	
+
 	function setRefreshToken($tenantKey, $refreshToken) {
 		if ($this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
-		}	
+		}
 		$this->tenantTokens[$tenantKey]['refreshToken'] = $refreshToken;
 	}
-	
+
 	function getRefreshToken($tenantKey) {
-		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;	
+		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;
 		if ($this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}
-		return isset($this->tenantTokens[$tenantKey]['refreshToken']) 
+		return isset($this->tenantTokens[$tenantKey]['refreshToken'])
 			? $this->tenantTokens[$tenantKey]['refreshToken']
 			: null;
-	}	
+	}
 
-	function AddSubscriberToList($emailAddress, $listIDs, $subscriberKey = null){                   
+	function AddSubscriberToList($emailAddress, $listIDs, $subscriberKey = null){
 		$newSub = new ET_Subscriber;
 		$newSub->authStub = $this;
 		$lists = array();
@@ -291,7 +295,7 @@ class ET_Client extends SoapClient {
 					}
 					$copyLists[$k] = $NewProps;
 				}
-				
+
 				$p = array("EmailAddress" => $emailAddress[$i], "Lists" => $copyLists);
 				if (is_array($subscriberKey) && $subscriberKey[$i] != null) {
 					$p['SubscriberKey']  = $subscriberKey[$i];
@@ -312,13 +316,13 @@ class ET_Client extends SoapClient {
         }
         return $postResponse;
     }
-	
+
 	function AddSubscribersToLists($subs, $listIDs){
 		//Create Lists
 		foreach ($listIDs as $key => $value){
 			$lists[] = array("ID" => $value);
 		}
-		
+
 		for ($i = 0; $i < count($subs); $i++) {
 			$copyLists = array();
 			foreach ($lists as $k => $v) {
@@ -330,21 +334,21 @@ class ET_Client extends SoapClient {
 			}
 			$subs[$i]["Lists"] = $copyLists;
 		}
-		
+
 		$response = new ET_Post($this, "Subscriber", $subs, true);
 		return $response;
     }
-  
-	
+
+
 	function CreateDataExtensions($dataExtensionDefinitions){
 		$newDEs = new ET_DataExtension();
 		$newDEs->authStub = $this;
 		$newDEs->props = $dataExtensionDefinitions;
 		$postResponse = $newDEs->post();
-		
+
 		return $postResponse;
 	}
-	
+
 	function SendTriggeredSends($arrayOfTriggeredRecords){
 		$sendTS = new ET_TriggeredSend();
 		$sendTS->authStub = $this;
@@ -352,7 +356,7 @@ class ET_Client extends SoapClient {
 		$sendResponse = $sendTS->send();
 		return $sendResponse;
 	}
-	
+
 	function SendEmailToList($emailID, $listID, $sendClassficationCustomerKey) {
 		$email = new ET_Email_SendDefinition();
 		$email->props = array("Name"=> uniqid(), "CustomerKey"=>uniqid(), "Description"=>"Created with FuelSDK");
@@ -361,41 +365,41 @@ class ET_Client extends SoapClient {
 		$email->props["Email"] = array("ID"=>$emailID);
 		$email->authStub = $this;
 		$result = $email->post();
-		
+
 		if ($result->status) {
 			$sendresult = $email->send();
 			if ($sendresult->status) {
 				$deleteresult = $email->delete();
 				return $sendresult;
-			} else { 
+			} else {
 				throw new Exception("Unable to send using send definition due to: ".print_r($result,true));
 			}
 		} else {
 			throw new Exception("Unable to create send definition due to: ".print_r($result,true));
 		}
 	}
-	
+
 	function SendEmailToDataExtension($emailID, $sendableDataExtensionCustomerKey, $sendClassficationCustomerKey){
 		$email = new ET_Email_SendDefinition();
-		$email->props = array("Name"=>uniqid(), "CustomerKey"=>uniqid(), "Description"=>"Created with FuelSDK"); 
+		$email->props = array("Name"=>uniqid(), "CustomerKey"=>uniqid(), "Description"=>"Created with FuelSDK");
 		$email->props["SendClassification"] = array("CustomerKey"=> $sendClassficationCustomerKey);
 		$email->props["SendDefinitionList"] = array("CustomerKey"=> $sendableDataExtensionCustomerKey, "DataSourceTypeID"=>"CustomObject");
 		$email->props["Email"] = array("ID"=>$emailID);
 		$email->authStub = $this;
 		$result = $email->post();
-		if ($result->status) { 
+		if ($result->status) {
 			$sendresult = $email->send();
-			if ($sendresult->status) { 
+			if ($sendresult->status) {
 				$deleteresult = $email->delete();
 				return $sendresult;
 			} else {
 				throw new Exception("Unable to send using send definition due to:".print_r($result,true));
-			} 
+			}
 		} else {
 			throw new Exception("Unable to create send definition due to: ".print_r($result,true));
-		} 
+		}
 	}
-	
+
 	function CreateAndStartListImport($listId,$fileName){
 		$import = new ET_Import();
 		$import->authStub = $this;
@@ -410,14 +414,14 @@ class ET_Client extends SoapClient {
 		$import->props["RetrieveFileTransferLocation"] = array("CustomerKey"=>"ExactTarget Enhanced FTP");
 		$import->props["UpdateType"] = "AddAndUpdate";
 		$result = $import->post();
-		
-		if ($result->status) { 
+
+		if ($result->status) {
 			return $import->start();
 		} else {
 			throw new Exception("Unable to create import definition due to: ".print_r($result,true));
-		} 
-	} 
-	
+		}
+	}
+
 	function CreateAndStartDataExtensionImport($dataExtensionCustomerKey, $fileName, $overwrite) {
 		$import = new ET_Import();
 		$import->authStub = $this;
@@ -434,17 +438,17 @@ class ET_Client extends SoapClient {
 			$import->props["UpdateType"] = "Overwrite";
 		} else {
 			$import->props["UpdateType"] = "AddAndUpdate";
-		} 
-		
+		}
+
 		$result = $import->post();
-		
+
 		if ($result->status) {
 			return $import->start();
 		} else {
 			throw new Exception("Unable to create import definition due to: ".print_r($result,true));
 		}
 	}
-	
+
 
 	function CreateProfileAttributes($allAttributes) {
 		$attrs = new ET_ProfileAttribute();
@@ -452,8 +456,8 @@ class ET_Client extends SoapClient {
 		$attrs->props = $allAttributes;
 		return $attrs->post();
 	}
-	
-	
+
+
 	function CreateContentAreas($arrayOfContentAreas) {
 		$postC = new ET_ContentArea();
 		$postC->authStub = $this;
@@ -461,37 +465,37 @@ class ET_Client extends SoapClient {
 		$sendResponse = $postC->post();
 		return $sendResponse;
 	}
-	
+
 }
 
 class ET_OEM_Client extends ET_Client {
-	
+
 	function CreateTenant($tenantInfo) {
 		$key = $tenantInfo['key'];
 		unset($tenantInfo['key']);
 		$additionalQS = array();
 		$additionalQS["access_token"] = $this->getAuthToken();
-		$queryString = http_build_query($additionalQS);		
+		$queryString = http_build_query($additionalQS);
 		$completeURL = "https://www.exacttargetapis.com/provisioning/v1/tenants/{$key}?{$queryString}";
 		return new ET_PutRest($this, $completeURL, $tenantInfo);
 	}
-	
+
 	function GetTenants() {
 		$additionalQS = array();
 		$additionalQS["access_token"] = $this->getAuthToken();
-		$queryString = http_build_query($additionalQS);		
+		$queryString = http_build_query($additionalQS);
 		$completeURL = "https://www.exacttargetapis.com/provisioning/v1/tenants/?{$queryString}";
 		return new ET_GetRest($this, $completeURL, $queryString);
 	}
-	
+
 }
 
 class ET_Constructor {
-	public $status, $code, $message, $results, $request_id, $moreResults;	
+	public $status, $code, $message, $results, $request_id, $moreResults;
 	function __construct($requestresponse, $httpcode, $restcall = false) {
-		
+
 		$this->code = $httpcode;
-		
+
 		if (!$restcall) {
 			if(is_soap_fault($requestresponse)) {
 				$this->status = false;
@@ -511,7 +515,7 @@ class ET_Constructor {
 				$this->results = json_decode($requestresponse);
 			} else  {
 				$this->message = $requestresponse;
-			}						
+			}
 		}
 	}
 }
@@ -522,23 +526,23 @@ class ET_Get extends ET_Constructor {
 		$rrm = array();
 		$request = array();
 		$retrieveRequest = array();
-		
+
 		// If Props is not sent then Info will be used to find all retrievable properties
-		if (is_null($props)){	
+		if (is_null($props)){
 			$props = array();
 			$info = new ET_Info($authStub, $objType);
-			if (is_array($info->results)){	
-				foreach ($info->results as $property){	
-					if($property->IsRetrievable){	
+			if (is_array($info->results)){
+				foreach ($info->results as $property){
+					if($property->IsRetrievable){
 						$props[] = $property->Name;
 					}
-				}	
+				}
 			}
 		}
-		
+
 		if (isAssoc($props)){
 			$retrieveProps = array();
-			foreach ($props as $key => $value){	
+			foreach ($props as $key => $value){
 				if (!is_array($value))
 				{
 					$retrieveProps[] = $key;
@@ -546,21 +550,21 @@ class ET_Get extends ET_Constructor {
 				$retrieveRequest["Properties"] = $retrieveProps;
 			}
 		} else {
-			$retrieveRequest["Properties"] = $props;	
+			$retrieveRequest["Properties"] = $props;
 		}
-		
+
 		$retrieveRequest["ObjectType"] = $objType;
 		if ("Account" == $objType) {
 			$retrieveRequest["QueryAllAccounts"] = true;
 		}
 		if ($filter){
-			if (array_key_exists("LogicalOperator",$filter )){				
+			if (array_key_exists("LogicalOperator",$filter )){
 				$cfp = new stdClass();
 				$cfp->LeftOperand = new SoapVar($filter["LeftOperand"], SOAP_ENC_OBJECT, 'SimpleFilterPart', "http://exacttarget.com/wsdl/partnerAPI");
-				$cfp->RightOperand = new SoapVar($filter["RightOperand"], SOAP_ENC_OBJECT, 'SimpleFilterPart', "http://exacttarget.com/wsdl/partnerAPI");				
+				$cfp->RightOperand = new SoapVar($filter["RightOperand"], SOAP_ENC_OBJECT, 'SimpleFilterPart', "http://exacttarget.com/wsdl/partnerAPI");
 				$cfp->LogicalOperator = $filter["LogicalOperator"];
 				$retrieveRequest["Filter"] = new SoapVar($cfp, SOAP_ENC_OBJECT, 'ComplexFilterPart', "http://exacttarget.com/wsdl/partnerAPI");
-				
+
 			} else {
 				$retrieveRequest["Filter"] = new SoapVar($filter, SOAP_ENC_OBJECT, 'SimpleFilterPart', "http://exacttarget.com/wsdl/partnerAPI");
 			}
@@ -568,14 +572,14 @@ class ET_Get extends ET_Constructor {
 		if ($getSinceLastBatch) {
 			$retrieveRequest["RetrieveAllSinceLastBatch"] = true;
 		}
-		
-		
+
+
 		$request["RetrieveRequest"] = $retrieveRequest;
 		$rrm["RetrieveRequestMsg"] = $request;
-		
+
 		$return = $authStub->__soapCall("Retrieve", $rrm, null, null , $out_header);
 		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
-		
+
 		if ($this->status){
 			if (property_exists($return, "Results")){
 				// We always want the results property when doing a retrieve to be an array
@@ -594,32 +598,32 @@ class ET_Get extends ET_Constructor {
 			}
 
 			$this->moreResults = false;
-			
-			if ($return->OverallStatus == "MoreDataAvailable") {				
+
+			if ($return->OverallStatus == "MoreDataAvailable") {
 				$this->moreResults = true;
 			}
-				
+
 			$this->request_id = $return->RequestID;
-		}	
+		}
 	}
 }
 
-class ET_Continue extends ET_Constructor {	
+class ET_Continue extends ET_Constructor {
 	function __construct($authStub, $request_id) {
 		$authStub->refreshToken();
-		$rrm = array(); 
-		$request = array(); 
-		$retrieveRequest = array(); 		
-		
+		$rrm = array();
+		$request = array();
+		$retrieveRequest = array();
+
 		$retrieveRequest["ContinueRequest"] = $request_id;
 		$retrieveRequest["ObjectType"] = null ;
 
 		$request["RetrieveRequest"] = $retrieveRequest;
 		$rrm["RetrieveRequestMsg"] = $request;
-		
+
 		$return = $authStub->__soapCall("Retrieve", $rrm, null, null , $out_header);
 		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
-		
+
 		if ($this->status){
 			if (property_exists($return, "Results")){
 				// We always want the results property when doing a retrieve to be an array
@@ -631,40 +635,40 @@ class ET_Continue extends ET_Constructor {
 			} else {
 				$this->results = array();
 			}
-			
+
 			$this->moreResults = false;
-			
-			if ($return->OverallStatus == "MoreDataAvailable") {				
+
+			if ($return->OverallStatus == "MoreDataAvailable") {
 				$this->moreResults = true;
 			}
-			
+
 			if ($return->OverallStatus != "OK" && $return->OverallStatus != "MoreDataAvailable")
 			{
 				$this->status = false;
 				$this->message = $return->OverallStatus;
 			}
-			
+
 			$this->request_id = $return->RequestID;
-		}		
-	
+		}
+
 	}
 }
 
 class ET_Info extends ET_Constructor {
 	function __construct($authStub, $objType, $extended = false) {
 		$authStub->refreshToken();
-		$drm = array(); 
-		$request = array(); 
-		$describeRequest = array(); 
-		
+		$drm = array();
+		$request = array();
+		$describeRequest = array();
+
 		$describeRequest["ObjectDefinitionRequest"] = array("ObjectType" => $objType);
 
 		$request["DescribeRequests"] = $describeRequest;
 		$drm["DefinitionRequestMsg"] = $request;
-		
+
 		$return = $authStub->__soapCall("Describe", $drm, null, null , $out_header);
 		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
-		
+
 		if ($this->status){
 			if (property_exists($return->ObjectDefinition, "Properties")){
 
@@ -675,28 +679,28 @@ class ET_Info extends ET_Constructor {
 					$this->results = $return->ObjectDefinition->Properties;
 				}
 			} else {
-				$this->status = false;				
+				$this->status = false;
 			}
-		}		
+		}
 	}
 }
 
-class ET_Post extends ET_Constructor {	
+class ET_Post extends ET_Constructor {
 	function __construct($authStub, $objType, $props, $upsert = false) {
 		$authStub->refreshToken();
-		$cr = array(); 
-		$objects = array(); 
-		
+		$cr = array();
+		$objects = array();
+
 		if (isAssoc($props)){
 			$objects["Objects"] = new SoapVar($props, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
 		} else {
 			$objects["Objects"] = array();
-			foreach($props as $object){				
+			foreach($props as $object){
 				$objects["Objects"][] = new SoapVar($object, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
 			}
-		}		
-		
-		
+		}
+
+
 		if ($upsert) {
 			$objects["Options"] = array('SaveOptions' => array('SaveOption' => array('PropertyName' => '*', 'SaveAction' => 'UpdateAdd' )));
 		} else {
@@ -704,8 +708,8 @@ class ET_Post extends ET_Constructor {
 		}
 		$cr["CreateRequest"] = $objects;
 		$return = $authStub->__soapCall("Create", $cr, null, null , $out_header);
-		parent::__construct($return, $authStub->__getLastResponseHTTPCode());		
-		
+		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
+
 		if ($this->status){
 			if (property_exists($return, "Results")){
 				// We always want the results property when doing a retrieve to be an array
@@ -716,23 +720,23 @@ class ET_Post extends ET_Constructor {
 				}
 			} else {
 				$this->status = false;
-				
+
 			}
 			if ($return->OverallStatus != "OK")
 			{
 				$this->status = false;
 			}
-		}			
+		}
 	}
 }
 
-class ET_Patch extends ET_Constructor {	
-	function __construct($authStub, $objType, $props,$upsert = false) {	
-		$authStub->refreshToken();	
-		$cr = array(); 
-		$objects = array(); 
-		$object = $props; 				
-		
+class ET_Patch extends ET_Constructor {
+	function __construct($authStub, $objType, $props,$upsert = false) {
+		$authStub->refreshToken();
+		$cr = array();
+		$objects = array();
+		$object = $props;
+
 		$objects["Objects"] = new SoapVar($props, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
 		if ($upsert) {
 			$objects["Options"] = array('SaveOptions' => array('SaveOption' => array('PropertyName' => '*', 'SaveAction' => 'UpdateAdd' )));
@@ -740,10 +744,10 @@ class ET_Patch extends ET_Constructor {
 			$objects["Options"] = "";
 		}
 		$cr["UpdateRequest"] = $objects;
-		
+
 		$return = $authStub->__soapCall("Update", $cr, null, null , $out_header);
-		parent::__construct($return, $authStub->__getLastResponseHTTPCode());		
-		
+		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
+
 		if ($this->status){
 			if (property_exists($return, "Results")){
 				// We always want the results property when doing a retrieve to be an array
@@ -754,30 +758,30 @@ class ET_Patch extends ET_Constructor {
 				}
 			} else {
 				$this->status = false;
-				
+
 			}
 			if ($return->OverallStatus != "OK")
 			{
 				$this->status = false;
 			}
-		}	
+		}
 	}
 }
 
-class ET_Delete extends ET_Constructor {	
-	function __construct($authStub, $objType, $props) {	
+class ET_Delete extends ET_Constructor {
+	function __construct($authStub, $objType, $props) {
 		$authStub->refreshToken();
-		$cr = array(); 
-		$objects = array(); 
-		$object = $props; 				
-		
+		$cr = array();
+		$objects = array();
+		$object = $props;
+
 		$objects["Objects"] = new SoapVar($props, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
 		$objects["Options"] = "";
 		$cr["DeleteRequest"] = $objects;
-		
+
 		$return = $authStub->__soapCall("Delete", $cr, null, null , $out_header);
-		parent::__construct($return, $authStub->__getLastResponseHTTPCode());		
-		
+		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
+
 		if ($this->status){
 			if (property_exists($return, "Results")){
 				// We always want the results property when doing a retrieve to be an array
@@ -793,7 +797,7 @@ class ET_Delete extends ET_Constructor {
 			{
 				$this->status = false;
 			}
-		}	
+		}
 	}
 }
 
@@ -804,19 +808,19 @@ class ET_Configure extends ET_Constructor {
 		$configureRequest = array();
 		$configureRequest['Action'] = $action;
 		$configureRequest['Configurations'] = array();
-		
+
 		if (!isAssoc($props)) {
 			foreach ($props as $value){
 				$configureRequest['Configurations'][] = new SoapVar($value, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
 			}
 		} else {
 			$configureRequest['Configurations'][] = new SoapVar($props, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
-		} 
+		}
 
 		$configure['ConfigureRequestMsg'] = $configureRequest;
 		$return = $authStub->__soapCall("Configure", $configure, null, null , $out_header);
 		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
-		
+
 		if ($this->status){
 			if (property_exists($return->Results, "Result")){
 				if (is_array($return->Results->Result)){
@@ -834,7 +838,7 @@ class ET_Configure extends ET_Constructor {
 	}
 }
 
-class ET_Perform extends ET_Constructor {	
+class ET_Perform extends ET_Constructor {
 	function __construct($authStub, $objType, $action, $props) {
 		$authStub->refreshToken();
 		$perform = array();
@@ -842,7 +846,7 @@ class ET_Perform extends ET_Constructor {
 		$performRequest['Action'] = $action;
 		$performRequest['Definitions'] = array();
 		$performRequest['Definitions'][] = new SoapVar($props, SOAP_ENC_OBJECT, $objType, "http://exacttarget.com/wsdl/partnerAPI");
-		
+
 		$perform['PerformRequestMsg'] = $performRequest;
 		$return = $authStub->__soapCall("Perform", $perform, null, null , $out_header);
 		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
@@ -869,35 +873,35 @@ class ET_GetSupportRest extends ET_BaseObjectRest{
 		$this->authStub->refreshToken();
 		$completeURL = $this->endpoint;
 		$additionalQS = array();
-		
+
 		if (!is_null($this->props)) {
 			foreach ($this->props as $key => $value){
 				if (in_array($key,$this->urlProps)){
-					$completeURL = str_replace("{{$key}}",$value,$completeURL);					
+					$completeURL = str_replace("{{$key}}",$value,$completeURL);
 				} else {
 					$additionalQS[$key] = $value;
 				}
-			}				
+			}
 		}
 		foreach($this->urlPropsRequired as $value){
 			if (is_null($this->props) || in_array($value,$this->props)){
-				throw new Exception("Unable to process request due to missing required prop: {$value}");							
+				throw new Exception("Unable to process request due to missing required prop: {$value}");
 			}
 		}
-		
+
 		// Clean up not required URL parameters
 		foreach ($this->urlProps as $value){
-			$completeURL = str_replace("{{$value}}","",$completeURL);								
-		}		
+			$completeURL = str_replace("{{$value}}","",$completeURL);
+		}
 		$additionalQS["access_token"] = $this->authStub->getAuthToken();
-		$queryString = http_build_query($additionalQS);		
+		$queryString = http_build_query($additionalQS);
 		$completeURL = "{$completeURL}?{$queryString}";
-		$response = new ET_GetRest($this->authStub, $completeURL, $queryString);						
-		
+		$response = new ET_GetRest($this->authStub, $completeURL, $queryString);
+
 		if (property_exists($response->results, 'page')){
 			$this->lastPageNumber = $response->results->page;
 			$pageSize = $response->results->pageSize;
-			
+
 			$count = null;
 			if (property_exists($response->results, 'count')){
 				$count = $response->results->count;
@@ -912,32 +916,32 @@ class ET_GetSupportRest extends ET_BaseObjectRest{
 
 		return $response;
 	}
-	
-	public function getMoreResults() {		
-	
+
+	public function getMoreResults() {
+
 		$originalPageValue = 1;
-		$removePageFromProps = false;		
-		
-		if ($this->props && array_key_exists($this->props, '$page')) { 
+		$removePageFromProps = false;
+
+		if ($this->props && array_key_exists($this->props, '$page')) {
 			$originalPageValue = $this->props['page'];
 		} else {
-			$removePageFromProps = true		;	
+			$removePageFromProps = true		;
 		}
-		
-		if (!$this->props) { 
+
+		if (!$this->props) {
 			$this->props = array();
 		}
-		
+
 		$this->props['$page'] = $this->lastPageNumber + 1;
-	
+
 		$response = $this->get();
-		
+
 		if ($removePageFromProps) {
 			unset($this->props['$page']);
 		} else {
 			$this->props['$page'] = $originalPageValue;
-		}			
-		
+		}
+
 		return $response;
 	}
 }
@@ -948,86 +952,86 @@ class ET_CUDSupportRest extends ET_GetSupportRest{
 		$this->authStub->refreshToken();
 		$completeURL = $this->endpoint;
 		$additionalQS = array();
-		
+
 		if (!is_null($this->props)) {
 			foreach ($this->props as $key => $value){
 				if (in_array($key,$this->urlProps)){
-					$completeURL = str_replace("{{$key}}",$value,$completeURL);					
-				} 
-			}				
-		}
-		
-		foreach($this->urlPropsRequired as $value){
-			if (is_null($this->props) || in_array($value,$this->props)){
-				throw new Exception("Unable to process request due to missing required prop: {$value}");							
+					$completeURL = str_replace("{{$key}}",$value,$completeURL);
+				}
 			}
 		}
-		
+
+		foreach($this->urlPropsRequired as $value){
+			if (is_null($this->props) || in_array($value,$this->props)){
+				throw new Exception("Unable to process request due to missing required prop: {$value}");
+			}
+		}
+
 		// Clean up not required URL parameters
 		foreach ($this->urlProps as $value){
-			$completeURL = str_replace("{{$value}}","",$completeURL);								
+			$completeURL = str_replace("{{$value}}","",$completeURL);
 		}
-		
+
 		$additionalQS["access_token"] = $this->authStub->getAuthToken();
-		$queryString = http_build_query($additionalQS);		
+		$queryString = http_build_query($additionalQS);
 		$completeURL = "{$completeURL}?{$queryString}";
-		$response = new ET_PostRest($this->authStub, $completeURL, $this->props);				
-		
+		$response = new ET_PostRest($this->authStub, $completeURL, $this->props);
+
 		return $response;
 	}
-	
+
 	public function patch() {
 		$this->authStub->refreshToken();
 		$completeURL = $this->endpoint;
 		$additionalQS = array();
-		
-		// All URL Props are required when doing Patch	
+
+		// All URL Props are required when doing Patch
 		foreach($this->urlProps as $value){
 			if (is_null($this->props) || !array_key_exists($value,$this->props)){
-				throw new Exception("Unable to process request due to missing required prop: {$value}");							
+				throw new Exception("Unable to process request due to missing required prop: {$value}");
 			}
 		}
-		
-		
+
+
 		if (!is_null($this->props)) {
 			foreach ($this->props as $key => $value){
 				if (in_array($key,$this->urlProps)){
-					$completeURL = str_replace("{{$key}}",$value,$completeURL);					
-				} 
-			}				
+					$completeURL = str_replace("{{$key}}",$value,$completeURL);
+				}
+			}
 		}
 		$additionalQS["access_token"] = $this->authStub->getAuthToken();
-		$queryString = http_build_query($additionalQS);		
+		$queryString = http_build_query($additionalQS);
 		$completeURL = "{$completeURL}?{$queryString}";
-		$response = new ET_PatchRest($this->authStub, $completeURL, $this->props);				
-		
+		$response = new ET_PatchRest($this->authStub, $completeURL, $this->props);
+
 		return $response;
 	}
-	
+
 	public function delete() {
 		$this->authStub->refreshToken();
 		$completeURL = $this->endpoint;
 		$additionalQS = array();
-		
-		// All URL Props are required when doing Delete	
+
+		// All URL Props are required when doing Delete
 		foreach($this->urlProps as $value){
 			if (is_null($this->props) || !array_key_exists($value,$this->props)){
-				throw new Exception("Unable to process request due to missing required prop: {$value}");							
+				throw new Exception("Unable to process request due to missing required prop: {$value}");
 			}
 		}
-		
+
 		if (!is_null($this->props)) {
 			foreach ($this->props as $key => $value){
 				if (in_array($key,$this->urlProps)){
-					$completeURL = str_replace("{{$key}}",$value,$completeURL);					
-				} 
-			}				
+					$completeURL = str_replace("{{$key}}",$value,$completeURL);
+				}
+			}
 		}
 		$additionalQS["access_token"] = $this->authStub->getAuthToken();
-		$queryString = http_build_query($additionalQS);		
+		$queryString = http_build_query($additionalQS);
 		$completeURL = "{$completeURL}?{$queryString}";
-		$response = new ET_DeleteRest($this->authStub, $completeURL);				
-		
+		$response = new ET_DeleteRest($this->authStub, $completeURL);
+
 		return $response;
 	}
 }
@@ -1036,49 +1040,49 @@ class ET_GetRest extends ET_Constructor {
 	function __construct($authStub, $url, $qs = null) {
 		$restResponse = restGet($url);
 		$this->moreResults = false;
-		parent::__construct($restResponse->body, $restResponse->httpcode, true);							
+		parent::__construct($restResponse->body, $restResponse->httpcode, true);
 	}
 }
 
 class ET_PostRest extends ET_Constructor {
 	function __construct($authStub, $url, $props) {
-		$restResponse = restPost($url, json_encode($props));			
-		parent::__construct($restResponse->body, $restResponse->httpcode, true);							
+		$restResponse = restPost($url, json_encode($props));
+		parent::__construct($restResponse->body, $restResponse->httpcode, true);
 	}
 }
 
 class ET_DeleteRest extends ET_Constructor {
-	function __construct($authStub, $url) {	
-		$restResponse = restDelete($url);			
-		parent::__construct($restResponse->body, $restResponse->httpcode, true);							
+	function __construct($authStub, $url) {
+		$restResponse = restDelete($url);
+		parent::__construct($restResponse->body, $restResponse->httpcode, true);
 	}
 }
 
 class ET_PatchRest extends ET_Constructor {
 	function __construct($authStub, $url, $props) {
-		$restResponse = restPatch($url, json_encode($props));			
-		parent::__construct($restResponse->body, $restResponse->httpcode, true);							
+		$restResponse = restPatch($url, json_encode($props));
+		parent::__construct($restResponse->body, $restResponse->httpcode, true);
 	}
 }
 
 class ET_PutRest extends ET_Constructor {
 	function __construct($authStub, $url, $props) {
-		$restResponse = restPut($url, json_encode($props));			
-		parent::__construct($restResponse->body, $restResponse->httpcode, true);							
+		$restResponse = restPut($url, json_encode($props));
+		parent::__construct($restResponse->body, $restResponse->httpcode, true);
 	}
 }
 
 class ET_Campaign extends ET_CUDSupportRest {
-	function __construct() {	
-		$this->endpoint = "https://www.exacttargetapis.com/hub/v1/campaigns/{id}";		
+	function __construct() {
+		$this->endpoint = "https://www.exacttargetapis.com/hub/v1/campaigns/{id}";
 		$this->urlProps = array("id");
 		$this->urlPropsRequired = array();
 	}
 }
 
 class ET_Campaign_Asset extends ET_CUDSupportRest {
-	function __construct() {	
-		$this->endpoint = "https://www.exacttargetapis.com/hub/v1/campaigns/{id}/assets/{assetId}";		
+	function __construct() {
+		$this->endpoint = "https://www.exacttargetapis.com/hub/v1/campaigns/{id}/assets/{assetId}";
 		$this->urlProps = array("id", "assetId");
 		$this->urlPropsRequired = array("id");
 	}
@@ -1102,46 +1106,46 @@ class ET_Message_Guide extends ET_CUDSupportRest {
 		$response = parent::get();
 		$this->endpoint = $origEndpoint;
 		$this->urlProps = $origProps;
-		
+
 		return $response;
 	}
-	
+
 	function convert() {
 		$completeURL = "https://www.exacttargetapis.com/guide/v1/messages/convert?access_token=" . $this->authStub->getAuthToken();
 
 		$response = new ET_PostRest($this->authStub, $completeURL, $this->props);
 		return $response;
-		
+
 	}
-	
+
 	function sendProcess() {
 		$renderMG = new ET_Message_Guide();
 		$renderMG->authStub = $this->authStub;
-		$renderMG->props = array("id" => $this->props['messageID']);	
+		$renderMG->props = array("id" => $this->props['messageID']);
 		$renderResult = $renderMG->render();
 		if(!$renderResult->status){
 			return $renderResult;
 		}
-		
+
 		$html = $renderResult->results->emailhtmlbody;
 		$send = array();
 		$send["Email"] = array("Subject"=> $this->props['subject'], "HTMLBody"=> $html);
-		$send["List"] = array("ID"=> $this->props['listID']);		
+		$send["List"] = array("ID"=> $this->props['listID']);
 		$response = new ET_Post($this->authStub, "Send", $send);
 		return $response;
 	}
-	
+
 	function render() {
 
 		$completeURL = null;
 		$response = null;
-		
+
 		if (is_array($this->props) && array_key_exists("id", $this->props)) {
 			$completeURL = "https://www.exacttargetapis.com/guide/v1/messages/render/{$this->props['id']}?access_token=" . $this->authStub->getAuthToken();
 			$response = new ET_GetRest($this->authStub, $completeURL, null);
 		} else {
 			$completeURL = "https://www.exacttargetapis.com/guide/v1/messages/render?access_token=" . $this->authStub->getAuthToken();
-			$response = new ET_PostRest($this->authStub, $completeURL, $this->props);			
+			$response = new ET_PostRest($this->authStub, $completeURL, $this->props);
 		}
 		return $response;
 	}
@@ -1153,16 +1157,16 @@ class ET_Asset extends ET_CUDSupportRest {
 		$this->urlProps = array("id");
 		$this->urlPropsRequired = array();
 	}
-	
+
 	public function upload() {
 		$completeURL = "https://www.exacttargetapis.com/guide/v1/contentItems/portfolio/fileupload?access_token=" . $this->authStub->getAuthToken();
 
 		$post = array('file_contents'=>'@'.$this->attrs['filePath']);
- 
+
         $ch = curl_init();
-        
+
 		$headers = array("User-Agent: ".getSDKVersion());
-		curl_setopt ($ch, CURLOPT_HTTPHEADER, $headers);	
+		curl_setopt ($ch, CURLOPT_HTTPHEADER, $headers);
 
 		curl_setopt($ch, CURLOPT_URL, $completeURL);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -1172,22 +1176,22 @@ class ET_Asset extends ET_CUDSupportRest {
 
 		// Disable VerifyPeer for SSL
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		
+
 		$outputJSON = curl_exec($ch);
 		curl_close ($ch);
-		
-		$responseObject = new stdClass(); 
+
+		$responseObject = new stdClass();
 		$responseObject->body = $outputJSON;
 		$responseObject->httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	
+
 		return $responseObject;
 	}
-	
+
 	public function patch() {
 		return null;
 	}
-	
-	public function delete() {	
+
+	public function delete() {
 		return null;
 	}
 }
@@ -1203,27 +1207,27 @@ class ET_BaseObjectRest {
 }
 
 class ET_GetSupport extends ET_BaseObject{
-	
+
 	public function get() {
 		$lastBatch = false;
 		if (property_exists($this,'getSinceLastBatch' )){
 			$lastBatch = $this->getSinceLastBatch;
 		}
 		$response = new ET_Get($this->authStub, $this->obj, $this->props, $this->filter, $lastBatch);
-		$this->lastRequestID = $response->request_id;		
+		$this->lastRequestID = $response->request_id;
 		return $response;
 	}
-	
+
 	public function getMoreResults() {
 		$response = new ET_Continue($this->authStub, $this->lastRequestID);
 		$this->lastRequestID = $response->request_id;
 		return $response;
 	}
-	
+
 	public function info() {
 		$response = new ET_Info($this->authStub, $this->obj);
 		return $response;
-	}	
+	}
 }
 
 class ET_CUDSupport extends ET_GetSupport{
@@ -1243,12 +1247,12 @@ class ET_CUDSupport extends ET_GetSupport{
 					$this->authStub->packageFolders = array();
 					foreach ($resultPackageFolder->results as $result){
 						$this->authStub->packageFolders[$result->ContentType] = $result->ID;
-					}	
+					}
 				} else {
 					throw new Exception('Unable to retrieve folders from account due to: '.$resultPackageFolder->message);
 				}
 			}
-			
+
 			if (!array_key_exists($this->folderMediaType,$this->authStub->packageFolders )){
 				if (is_null($this->authStub->parentFolders)) {
 					$parentFolders = new ET_Folder();
@@ -1256,11 +1260,11 @@ class ET_CUDSupport extends ET_GetSupport{
 					$parentFolders->props = array("ID", "ContentType");
 					$parentFolders->filter = array("Property" => "ParentFolder.ID", "SimpleOperator" => "equals", "Value" => "0");
 					$resultParentFolders = $parentFolders->get();
-					if ($resultParentFolders->status) { 
+					if ($resultParentFolders->status) {
 						$this->authStub->parentFolders = array();
 						foreach ($resultParentFolders->results as $result){
 							$this->authStub->parentFolders[$result->ContentType] = $result->ID;
-						}	
+						}
 					} else {
 						throw new Exception('Unable to retrieve folders from account due to: '.$resultParentFolders->message);
 					}
@@ -1276,8 +1280,8 @@ class ET_CUDSupport extends ET_GetSupport{
 				}
 			}
 			$this->props[$this->folderProperty] = $this->authStub->packageFolders[$this->folderMediaType];
-		} 
-		
+		}
+
 		$response = new ET_Post($this->authStub, $this->obj, $this->props);
 		$this->props = $originalProps;
 		return $response;
@@ -1287,16 +1291,16 @@ class ET_CUDSupport extends ET_GetSupport{
 		$originalProps = $this->props;
 		if (property_exists($this, 'folderProperty') && !is_null($this->folderProperty) && !is_null($this->folderId)){
 			$this->props[$this->folderProperty] = $this->folderId;
-		} 
+		}
 		$response = new ET_Patch($this->authStub, $this->obj, $this->props);
 		$this->props = $originalProps;
 		return $response;
 	}
-	
-	public function delete() {	
+
+	public function delete() {
 		$response = new ET_Delete($this->authStub, $this->obj, $this->props);
 		return $response;
-	}	
+	}
 }
 
 class ET_CUDWithUpsertSupport extends ET_CUDSupport{
@@ -1304,7 +1308,7 @@ class ET_CUDWithUpsertSupport extends ET_CUDSupport{
 		$originalProps = $this->props;
 		if (property_exists($this, 'folderProperty') && !is_null($this->folderProperty) && !is_null($this->folderId)){
 			$this->props[$this->folderProperty] = $this->folderId;
-		} 
+		}
 		$response = new ET_Patch($this->authStub, $this->obj, $this->props, true);
 		$this->props = $originalProps;
 		return $response;
@@ -1315,25 +1319,25 @@ class ET_CUDWithUpsertSupport extends ET_CUDSupport{
 class ET_Subscriber extends ET_CUDWithUpsertSupport {
 	function __construct() {
 		$this->obj = "Subscriber";
-	}	
+	}
 }
 
 class ET_DataExtension extends ET_CUDSupport {
 	public  $columns;
-	function __construct() {	
+	function __construct() {
 		$this->obj = "DataExtension";
 	}
-	
+
 	public function post() {
-		
+
 		$originalProps = $this->props;
-		if (isAssoc($this->props)){			
-			$this->props["Fields"] = array("Field"=>array());		
+		if (isAssoc($this->props)){
+			$this->props["Fields"] = array("Field"=>array());
 			if (!is_null($this->columns) && is_array($this->columns)){
 				foreach ($this->columns as $column){
 					array_push($this->props['Fields']['Field'], $column);
-				}	
-			}							
+				}
+			}
 		} else {
 			$newProps = array();
 			foreach ($this->props as $DE) {
@@ -1342,128 +1346,128 @@ class ET_DataExtension extends ET_CUDSupport {
 				if (!is_null($DE['columns']) && is_array($DE['columns'])){
 					foreach ($DE['columns'] as $column){
 						array_push($newDE['Fields']['Field'], $column);
-					}						
+					}
 				}
 				array_push($newProps, $newDE);
 			}
-			$this->props = $newProps;					
+			$this->props = $newProps;
 		}
-		
+
 		$response = parent::post();
-		
+
 		$this->props = $originalProps;
 		return $response;
 	}
-	
-	public function patch() {				
-		$this->props["Fields"] = array("Field"=>array());				
+
+	public function patch() {
+		$this->props["Fields"] = array("Field"=>array());
 		foreach ($this->columns as $column){
 			array_push($this->props['Fields']['Field'], $column);
-		}	
-		$response = parent::patch();		
-		unset($this->props["Fields"]);		
+		}
+		$response = parent::patch();
+		unset($this->props["Fields"]);
 		return $response;
 	}
 }
 
 class ET_DataExtension_Column extends ET_GetSupport {
-	function __construct() {	
+	function __construct() {
 		$this->obj = "DataExtensionField";
 		$this->folderProperty = "CategoryID";
 		$this->folderMediaType = "dataextension";
 	}
-	
-	public function get() {	
+
+	public function get() {
 		$fixCustomerKey = false;
-		
+
 		if ($this->filter && array_key_exists('Property', $this->filter) && $this->filter['Property'] == "CustomerKey" )
-		{	
+		{
 			$this->filter['Property'] = "DataExtension.CustomerKey";
 			$fixCustomerKey = true;
-		}				
-		$response =  parent::get();	
+		}
+		$response =  parent::get();
 		if ($fixCustomerKey )
 		{
 			$this->filter['Property'] = "CustomerKey";
 		}
-		
+
 		return $response;
 	}
 }
 
 class ET_DataExtension_Row extends ET_CUDWithUpsertSupport {
 	public $Name, $CustomerKey;
-	function __construct() {	
+	function __construct() {
 		$this->obj = "DataExtensionObject";
 	}
-	
-	public function get() {	
-		$this->getName();		
-		$this->obj = "DataExtensionObject[".$this->Name."]";		
+
+	public function get() {
+		$this->getName();
+		$this->obj = "DataExtensionObject[".$this->Name."]";
 		$response = parent::get();
 		$this->obj = "DataExtensionObject";
 		return $response;
 	}
-	
+
 	public function post(){
 		$this->getCustomerKey();
-		$originalProps = $this->props;		
+		$originalProps = $this->props;
 		$overrideProps = array();
 		$fields = array();
-		
+
 		foreach ($this->props as $key => $value){
-			$fields[]  = array("Name" => $key, "Value" => $value);	
-		}		
+			$fields[]  = array("Name" => $key, "Value" => $value);
+		}
 		$overrideProps['CustomerKey'] = $this->CustomerKey;
 		$overrideProps['Properties'] = array("Property"=> $fields);
-		
-		$this->props = $overrideProps;		
-		$response = parent::post();		
+
+		$this->props = $overrideProps;
+		$response = parent::post();
 		$this->props = $originalProps;
 		return $response;
 	}
-	
+
 	public function patch(){
 		$this->getCustomerKey();
-		$originalProps = $this->props;		
+		$originalProps = $this->props;
 		$overrideProps = array();
 		$fields = array();
-		
+
 		foreach ($this->props as $key => $value){
-			$fields[]  = array("Name" => $key, "Value" => $value);	
-		}		
+			$fields[]  = array("Name" => $key, "Value" => $value);
+		}
 		$overrideProps['CustomerKey'] = $this->CustomerKey;
 		$overrideProps['Properties'] = array("Property"=> $fields);
-		
-		$this->props = $overrideProps;		
-		$response = parent::patch();		
+
+		$this->props = $overrideProps;
+		$response = parent::patch();
 		$this->props = $originalProps;
 		return $response;
 	}
-	
+
 	public function delete(){
 		$this->getCustomerKey();
-		$originalProps = $this->props;		
+		$originalProps = $this->props;
 		$overrideProps = array();
 		$fields = array();
-		
+
 		foreach ($this->props as $key => $value){
-			$fields[]  = array("Name" => $key, "Value" => $value);	
-		}		
+			$fields[]  = array("Name" => $key, "Value" => $value);
+		}
 		$overrideProps['CustomerKey'] = $this->CustomerKey;
 		$overrideProps['Keys'] = array("Key"=> $fields);
-		
-		$this->props = $overrideProps;		
-		$response = parent::delete();		
+
+		$this->props = $overrideProps;
+		$response = parent::delete();
 		$this->props = $originalProps;
 		return $response;
 	}
-	
+
 	private function getName() {
 		if (is_null($this->Name)){
 			if (is_null($this->CustomerKey))
 			{
-				throw new Exception('Unable to process request due to CustomerKey and Name not being defined on ET_DataExtension_Row');			
+				throw new Exception('Unable to process request due to CustomerKey and Name not being defined on ET_DataExtension_Row');
 			} else {
 				$nameLookup = new ET_DataExtension();
 				$nameLookup->authStub = $this->authStub;
@@ -1473,16 +1477,16 @@ class ET_DataExtension_Row extends ET_CUDWithUpsertSupport {
 				if ($nameLookupGet->status && count($nameLookupGet->results) == 1){
 					$this->Name = $nameLookupGet->results[0]->Name;
 				} else {
-					throw new Exception('Unable to process request due to unable to find DataExtension based on CustomerKey');				
-				}								
-			}					
-		}		
+					throw new Exception('Unable to process request due to unable to find DataExtension based on CustomerKey');
+				}
+			}
+		}
 	}
 	private function getCustomerKey() {
 		if (is_null($this->CustomerKey)){
 			if (is_null($this->Name))
 			{
-				throw new Exception('Unable to process request due to CustomerKey and Name not being defined on ET_DataExtension_Row');			
+				throw new Exception('Unable to process request due to CustomerKey and Name not being defined on ET_DataExtension_Row');
 			} else {
 				$nameLookup = new ET_DataExtension();
 				$nameLookup->authStub = $this->authStub;
@@ -1492,11 +1496,11 @@ class ET_DataExtension_Row extends ET_CUDWithUpsertSupport {
 				if ($nameLookupGet->status && count($nameLookupGet->results) == 1){
 					$this->CustomerKey = $nameLookupGet->results[0]->CustomerKey;
 				} else {
-					throw new Exception('Unable to process request due to unable to find DataExtension based on Name');				
-				}								
-			}					
-		}		
-	}	
+					throw new Exception('Unable to process request due to unable to find DataExtension based on Name');
+				}
+			}
+		}
+	}
 }
 
 class ET_ContentArea extends ET_CUDSupport {
@@ -1510,7 +1514,7 @@ class ET_ContentArea extends ET_CUDSupport {
 
 class ET_Email extends ET_CUDSupport {
 	public  $folderId;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "Email";
 		$this->folderProperty = "CategoryID";
@@ -1520,15 +1524,15 @@ class ET_Email extends ET_CUDSupport {
 
 class ET_Email_SendDefinition extends ET_CUDSupport {
 	public  $folderId,  $lastTaskID;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "EmailSendDefinition";
 		$this->folderProperty = "CategoryID";
 		$this->folderMediaType = "userinitiatedsends";
 	}
-	
+
 	function send(){
-		$originalProps = $this->props;		
+		$originalProps = $this->props;
 		$response = new ET_Perform($this->authStub, $this->obj, 'start', $this->props);
 		if ($response->status) {
 			$this->lastTaskID = $response->results[0]->Task->ID;
@@ -1536,7 +1540,7 @@ class ET_Email_SendDefinition extends ET_CUDSupport {
 		$this->props = $originalProps;
 		return $response;
 	}
-	
+
 	function status(){
 		$this->filter = array('Property' => 'ID','SimpleOperator' => 'equals','Value' => $this->lastTaskID);
 		$response = new ET_Get($this->authStub, 'Send', array('ID','CreatedDate', 'ModifiedDate', 'Client.ID', 'Email.ID', 'SendDate','FromAddress','FromName','Duplicates','InvalidAddresses','ExistingUndeliverables','ExistingUnsubscribes','HardBounces','SoftBounces','OtherBounces','ForwardedEmails','UniqueClicks','UniqueOpens','NumberSent','NumberDelivered','NumberTargeted','NumberErrored','NumberExcluded','Unsubscribes','MissingAddresses','Subject','PreviewURL','SentDate','EmailName','Status','IsMultipart','SendLimit','SendWindowOpen','SendWindowClose','BCCEmail','EmailSendDefinition.ObjectID','EmailSendDefinition.CustomerKey'), $this->filter);
@@ -1548,28 +1552,28 @@ class ET_Email_SendDefinition extends ET_CUDSupport {
 
 class ET_Import extends ET_CUDSupport {
 	public  $lastTaskID;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "ImportDefinition";
 	}
-	
+
 	function post() {
 		$originalProp = $this->props;
-		
+
 		# If the ID property is specified for the destination then it must be a list import
 		if (array_key_exists('DestinationObject', $this->props)) {
 			if (array_key_exists('ID', $this->props['DestinationObject'])){
 				$this->props['DestinationObject'] = new SoapVar($this->props['DestinationObject'], SOAP_ENC_OBJECT, 'List', "http://exacttarget.com/wsdl/partnerAPI");
 			}
 		}
-		
+
 		$obj = parent::post();
 		$this->props = $originalProp;
 		return $obj;
 	}
-	
+
 	function start(){
-		$originalProps = $this->props;		
+		$originalProps = $this->props;
 		$response = new ET_Perform($this->authStub, $this->obj, 'start', $this->props);
 		if ($response->status) {
 			$this->lastTaskID = $response->results[0]->Task->ID;
@@ -1577,7 +1581,7 @@ class ET_Import extends ET_CUDSupport {
 		$this->props = $originalProps;
 		return $response;
 	}
-	
+
 	function status(){
 		$this->filter = array('Property' => 'TaskResultID','SimpleOperator' => 'equals','Value' => $this->lastTaskID);
 		$response = new ET_Get($this->authStub, 'ImportResultsSummary', array('ImportDefinitionCustomerKey','TaskResultID','ImportStatus','StartDate','EndDate','DestinationID','NumberSuccessful','NumberDuplicated','NumberErrors','TotalRows','ImportType'), $this->filter);
@@ -1587,32 +1591,32 @@ class ET_Import extends ET_CUDSupport {
 }
 
 class ET_ProfileAttribute extends ET_BaseObject {
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "PropertyDefinition";
 	}
-	
+
 	function post(){
 		return new ET_Configure($this->authStub, $this->obj, "create", $this->props);
 	}
-	
+
 	function get(){
 		return new ET_Info($this->authStub, 'Subscriber', true);
 	}
-	
+
 	function patch() {
 		return new ET_Configure($this->authStub, $this->obj, "update", $this->props);
 	}
-	
+
 	function delete() {
 		return new ET_Configure($this->authStub, $this->obj, "delete", $this->props);
 	}
-	
+
 }
 
 
-class ET_Folder extends ET_CUDSupport {		
-	function __construct() {	
+class ET_Folder extends ET_CUDSupport {
+	function __construct() {
 		$this->obj = "DataFolder";
 	}
 }
@@ -1634,12 +1638,12 @@ class ET_List_Subscriber extends ET_GetSupport {
 
 class ET_TriggeredSend extends ET_CUDSupport {
 	public  $subscribers, $folderId, $client;
-	function __construct() {	
+	function __construct() {
 		$this->obj = "TriggeredSendDefinition";
 		$this->folderProperty = "CategoryID";
 		$this->folderMediaType = "triggered_send";
 	}
-	
+
 	public function Send( $clientMID = null ) {
 		$tscall = array("TriggeredSendDefinition" => $this->props , "Subscribers" => $this->subscribers);
 		if( !empty( $clientMID ) && "string" == gettype( $clientMID ) ) {
@@ -1653,7 +1657,7 @@ class ET_TriggeredSend extends ET_CUDSupport {
 // Tracking Events
 class ET_SentEvent extends ET_GetSupport {
 	public  $getSinceLastBatch;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "SentEvent";
 		$this->getSinceLastBatch = true;
@@ -1662,7 +1666,7 @@ class ET_SentEvent extends ET_GetSupport {
 
 class ET_OpenEvent extends ET_GetSupport {
 	public  $getSinceLastBatch;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "OpenEvent";
 		$this->getSinceLastBatch = true;
@@ -1671,7 +1675,7 @@ class ET_OpenEvent extends ET_GetSupport {
 
 class ET_BounceEvent extends ET_GetSupport {
 	public  $getSinceLastBatch;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "BounceEvent";
 		$this->getSinceLastBatch = true;
@@ -1680,7 +1684,7 @@ class ET_BounceEvent extends ET_GetSupport {
 
 class ET_UnsubEvent extends ET_GetSupport {
 	public  $getSinceLastBatch;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "UnsubEvent";
 		$this->getSinceLastBatch = true;
@@ -1689,7 +1693,7 @@ class ET_UnsubEvent extends ET_GetSupport {
 
 class ET_ClickEvent extends ET_GetSupport {
 	public  $getSinceLastBatch;
-	function __construct() 
+	function __construct()
 	{
 		$this->obj = "ClickEvent";
 		$this->getSinceLastBatch = true;
@@ -1716,18 +1720,18 @@ function restGet($url) {
 	// Uses the URL passed in that is specific to the API used
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_HTTPGET, true);
-	
+
 	// Need to set ReturnTransfer to True in order to store the result in a variable
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	
+
 	// Disable VerifyPeer for SSL
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-	
+
 	$outputJSON = curl_exec($ch);
-	$responseObject = new stdClass(); 
+	$responseObject = new stdClass();
 	$responseObject->body = $outputJSON;
 	$responseObject->httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	
+
 	return $responseObject;
 }
 
@@ -1740,28 +1744,28 @@ function restGet($url) {
  */
 function restPost($url, $content) {
 	$ch = curl_init();
-	
+
 	// Uses the URL passed in that is specific to the API used
-	curl_setopt($ch, CURLOPT_URL, $url);	
-	
+	curl_setopt($ch, CURLOPT_URL, $url);
+
 	// When posting to a Fuel API, content-type has to be explicitly set to application/json
 	$headers = array("Content-Type: application/json", "User-Agent: ".getSDKVersion());
 	curl_setopt ($ch, CURLOPT_HTTPHEADER, $headers);
-	
+
 	// The content is the JSON payload that defines the request
 	curl_setopt ($ch, CURLOPT_POSTFIELDS, $content);
-	
+
 	//Need to set ReturnTransfer to True in order to store the result in a variable
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	
+
 	// Disable VerifyPeer for SSL
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-	
+
 	$outputJSON = curl_exec($ch);
-	$responseObject = new stdClass(); 
+	$responseObject = new stdClass();
 	$responseObject->body = $outputJSON;
 	$responseObject->httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	
+
 	return $responseObject;
 }
 
@@ -1775,31 +1779,31 @@ function restPost($url, $content) {
  */
 function restPatch($url, $content) {
 	$ch = curl_init();
-	
+
 	// Uses the URL passed in that is specific to the API used
-	curl_setopt($ch, CURLOPT_URL, $url);	
-	
+	curl_setopt($ch, CURLOPT_URL, $url);
+
 	// When posting to a Fuel API, content-type has to be explicitly set to application/json
 	$headers = array("Content-Type: application/json", "User-Agent: ".getSDKVersion());
 	curl_setopt ($ch, CURLOPT_HTTPHEADER, $headers);
-	
+
 	// The content is the JSON payload that defines the request
 	curl_setopt ($ch, CURLOPT_POSTFIELDS, $content);
-	
+
 	//Need to set ReturnTransfer to True in order to store the result in a variable
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	
+
 	//Need to set the request to be a PATCH
-	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH" ); 
-		
+	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH" );
+
 	// Disable VerifyPeer for SSL
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-	
+
 	$outputJSON = curl_exec($ch);
-	$responseObject = new stdClass(); 
+	$responseObject = new stdClass();
 	$responseObject->body = $outputJSON;
 	$responseObject->httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	
+
 	return $responseObject;
 }
 
@@ -1812,61 +1816,61 @@ function restPatch($url, $content) {
  */
 function restPut($url, $content) {
 	$ch = curl_init();
-	
+
 	// Uses the URL passed in that is specific to the API used
-	curl_setopt($ch, CURLOPT_URL, $url);	
-	
+	curl_setopt($ch, CURLOPT_URL, $url);
+
 	// When posting to a Fuel API, content-type has to be explicitly set to application/json
 	$headers = array("Content-Type: application/json", "User-Agent: ".getSDKVersion());
 	curl_setopt ($ch, CURLOPT_HTTPHEADER, $headers);
-	
+
 	// The content is the JSON payload that defines the request
 	curl_setopt ($ch, CURLOPT_POSTFIELDS, $content);
-	
+
 	//Need to set ReturnTransfer to True in order to store the result in a variable
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	
+
 	//Need to set the request to be a PATCH
-	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT" ); 
-		
+	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT" );
+
 	// Disable VerifyPeer for SSL
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-	
+
 	$outputJSON = curl_exec($ch);
-	$responseObject = new stdClass(); 
+	$responseObject = new stdClass();
 	$responseObject->body = $outputJSON;
 	$responseObject->httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	
+
 	return $responseObject;
 }
 
 function restDelete($url) {
 	$ch = curl_init();
-	
+
 	$headers = array("User-Agent: ".getSDKVersion());
 	curl_setopt ($ch, CURLOPT_HTTPHEADER, $headers);
-	
+
 	// Uses the URL passed in that is specific to the API used
 	curl_setopt($ch, CURLOPT_URL, $url);
 	curl_setopt($ch, CURLOPT_HTTPGET, true);
-	
+
 	// Need to set ReturnTransfer to True in order to store the result in a variable
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	
+
 	// Disable VerifyPeer for SSL
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-	
-	// Set CustomRequest up for Delete	
+
+	// Set CustomRequest up for Delete
 	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
-	
-	$http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);	
-	
+
+	$http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
 	$outputJSON = curl_exec($ch);
 
-	$responseObject = new stdClass(); 
+	$responseObject = new stdClass();
 	$responseObject->body = $outputJSON;
 	$responseObject->httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	
+
 	return $responseObject;
 }
 


### PR DESCRIPTION
I was having an issue on my system where even though the include of the config file was prepended by the `@` operator, PHP was silently dying when that file didn't exist.

This commit changes `ET_Client::__construct()` to check if the config file exists before it attempts to include it. Any other changes are simple white space removals.
