### PR TITLE
Minor ET_Client::__doRequest() Compatibility Fix

### DIFF
--- a/ET_Client.php
+++ b/ET_Client.php
@@ -156,7 +156,7 @@ class ET_Client extends SoapClient {
 		return curl_getinfo($curl, CURLINFO_FILETIME);
 	}
 				
-	function __doRequest($request, $location, $saction, $version) {
+	function __doRequest($request, $location, $saction, $version, $one_way = 0) {
 		$doc = new DOMDocument();
 		$doc->loadXML($request);
 		


### PR DESCRIPTION
ET_Client::__doRequest() compatibility fix.  If PHP error level is strict (part of E_ALL in v.5.4.0) is set, there is the following PHP error: PHP Strict Standards:  Declaration of ET_Client::__doRequest() should be compatible with SoapClient::__doRequest($request, $location, $action, $version, $one_way = NULL) in /path/to/FuelSDK/ET_Client.php.  This fix simply adds a setting and default value for $one_way.  See: http://www.php.net/manual/en/soapclient.dorequest.php.
