### PR TITLE
Support use of the ExactTarget sandbox

### DIFF
--- a/ET_Client.php
+++ b/ET_Client.php
@@ -6,7 +6,7 @@ class ET_Client extends SoapClient {
 	public $packageName, $packageFolders, $parentFolders;
 	private $wsdlLoc, $debugSOAP, $lastHTTPCode, $clientId, 
 			$clientSecret, $appsignature, $endpoint, 
-			$tenantTokens, $tenantKey;
+			$tenantTokens, $tenantKey, $authLoc;
 		
 	function __construct($getWSDL = false, $debug = false, $params = null) {	
 		$tenantTokens = array();
@@ -20,12 +20,14 @@ class ET_Client extends SoapClient {
 			$this->clientId = $config['clientid'];
 			$this->clientSecret = $config['clientsecret'];
 			$this->appsignature = $config['appsignature'];
+			$this->authLoc = isset($config['authendpoint']) ? $config['auth'] : null;
 		} else {
 			if ($params && array_key_exists('defaultwsdl', $params)){$this->wsdlLoc = $params['defaultwsdl'];}
 			else {$this->wsdlLoc = "https://webservice.exacttarget.com/etframework.wsdl";}
 			if ($params && array_key_exists('clientid', $params)){$this->clientId = $params['clientid'];}
 			if ($params && array_key_exists('clientsecret', $params)){$this->clientSecret = $params['clientsecret'];}
 			if ($params && array_key_exists('appsignature', $params)){$this->appsignature = $params['appsignature'];}
+			if ($params && array_key_exists('authendpoint', $params)){$this->authLoc = $params['authendpoint'];}
 		}
 		
 		$this->debugSOAP = $debug;
@@ -81,7 +83,7 @@ class ET_Client extends SoapClient {
 
 			if (is_null($this->getAuthToken($this->tenantKey)) || ($timeDiff < 5) || $forceRefresh  ){
 				$url = $this->tenantKey == null 
-						? "https://auth.exacttargetapis.com/v1/requestToken?legacy=1"
+						? $this->authLoc ? ($this->authLoc . "?legacy=1") : "https://auth.exacttargetapis.com/v1/requestToken?legacy=1"
 						: "https://www.exacttargetapis.com/provisioning/v1/tenants/{$this->tenantKey}/requestToken?legacy=1";
 				$jsonRequest = new stdClass(); 
 				$jsonRequest->clientId = $this->clientId;


### PR DESCRIPTION
The authentication URL is hard-coded into the library. This patch allows it to be configured so that the sandbox auth URL can be used instead. See ExactTarget Case #01110440 for more details.