### PR TITLE
The delete a row syntax is incorrect

### DIFF
--- a/objsamples/sample-dataextension.php
+++ b/objsamples/sample-dataextension.php
@@ -174,7 +174,7 @@ try {
 	print_r("Delete a row from a DataExtension   \n");
 	$deleteDRRow = new ET_DataExtension_Row();
 	$deleteDRRow->authStub = $myclient;
-	$deleteDRRow->props = array("Key" => "PHPSDKTEST2", "Value" => "ItWorksUPDATED!");
+	$deleteDRRow->props = array("PHPSDKTEST2" => "ItWorksUPDATED!");
 	$deleteDRRow->CustomerKey = $DataExtensionNameForTesting;	
 	$deleteResult = $deleteDRRow->delete();
 	print_r('Delete Status: '.($deleteResult->status ? 'true' : 'false')."\n");


### PR DESCRIPTION
The array syntax around the keys doesn't work as documented. I edited it to align with the (working) example presented on [code.exacttarget.](https://code.exacttarget.com/sdks/fuel-sdk-interacting-data-extension-rows#Deleting)