### PR TITLE
Allow the override of config.php values in constructor, and update readme for .9 flexible auth.

### DIFF
--- a/ET_Client.php
+++ b/ET_Client.php
@@ -16,26 +16,26 @@ class ET_Client extends SoapClient {
 			$config = include 'config.php';
 
 		if ($config){
-			$this->wsdlLoc = $config['defaultwsdl'];
-			$this->clientId = $config['clientid'];
-			$this->clientSecret = $config['clientsecret'];
-			$this->appsignature = $config['appsignature'];
-		} else {
-			if ($params && array_key_exists('defaultwsdl', $params)){$this->wsdlLoc = $params['defaultwsdl'];}
-			else {$this->wsdlLoc = "https://webservice.exacttarget.com/etframework.wsdl";}
-			if ($params && array_key_exists('clientid', $params)){$this->clientId = $params['clientid'];}
-			if ($params && array_key_exists('clientsecret', $params)){$this->clientSecret = $params['clientsecret'];}
-			if ($params && array_key_exists('appsignature', $params)){$this->appsignature = $params['appsignature'];}
+			if(array_key_exists('defaultwsdl', $config)) { $this->wsdlLoc = $config['defaultwsdl']; }
+			if(array_key_exists('clientid', $config)) { $this->clientId = $config['clientid']; }
+			if(array_key_exists('clientsecret', $config)) { $this->clientSecret = $config['clientsecret']; }
+			if(array_key_exists('appsignature', $config)) { $this->appsignature = $config['appsignature']; }
 		}
-		
+
+		if ($params && array_key_exists('defaultwsdl', $params)){$this->wsdlLoc = $params['defaultwsdl'];}
+		else {$this->wsdlLoc = "https://webservice.exacttarget.com/etframework.wsdl";}
+		if ($params && array_key_exists('clientid', $params)){$this->clientId = $params['clientid'];}
+		if ($params && array_key_exists('clientsecret', $params)){$this->clientSecret = $params['clientsecret'];}
+		if ($params && array_key_exists('appsignature', $params)){$this->appsignature = $params['appsignature'];}
+
 		$this->debugSOAP = $debug;
-		
+
 		if (!property_exists($this,'clientId') || is_null($this->clientId) || !property_exists($this,'clientSecret') || is_null($this->clientSecret)){
 			throw new Exception('clientid or clientsecret is null: Must be provided in config file or passed when instantiating ET_Client');
 		}
-		
+
 		if ($getWSDL){$this->CreateWSDL($this->wsdlLoc);}
-		
+
 		if ($params && array_key_exists('jwt', $params)){
 			if (!property_exists($this,'appsignature') || is_null($this->appsignature)){
 				throw new Exception('Unable to utilize JWT for SSO without appsignature: Must be provided in config file or passed when instantiating ET_Client');

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ The ET_Client class accepts multiple parameters
 
 **Parameters** - Allows for passing authentication information for use with SSO with a JWT or for passing ClientID/ClientSecret if you would prefer to not use the config file option. 
 
-Example passing JWT: 
-> $myclient = new ET_Client(true, array("jwt"=>"JWT Values goes here"));
+Example passing JWT:
+> $myclient = new ET_Client(true, false, array("jwt"=>"JWT Values goes here"));
 
-Example passing ClientID/ClientSecret: 
-> $myclient = new ET_Client(true, array("clientid" => "3bjbc3mg4nbk64z5kzczf89n", "clientsecret"=>"ssnGAPvZg6kmm775KPj2Q4Cs"));
+Example passing ClientID/ClientSecret:
+> $myclient = new ET_Client(true, false, array("clientid" => "3bjbc3mg4nbk64z5kzczf89n", "clientsecret"=>"ssnGAPvZg6kmm775KPj2Q4Cs"));
 
 ## Responses ##
 All methods on Fuel SDK objects return a generic object that follows the same structure, regardless of the type of call.  This object contains a common set of properties used to display details about the request.


### PR DESCRIPTION
I've added the ability to override the config.php values on ET_Client creation, as requested in issue #30.

I've also updated the README to reflect the flexible auth handler in the .9 release.