### PR TITLE
exposing retrieveRequest

### DIFF
--- a/src/ET_DataExtension_Row.php
+++ b/src/ET_DataExtension_Row.php
@@ -18,7 +18,6 @@ class ET_DataExtension_Row extends ET_CUDWithUpsertSupport
 	* @var string 			Gets or sets the data extension customer key.
 	*/
 	public $CustomerKey;
-
 	/** 
 	* Initializes a new instance of the class.
 	*/
@@ -43,20 +42,25 @@ class ET_DataExtension_Row extends ET_CUDWithUpsertSupport
     /**
 	* Post this instance.
     * @return ET_Post     Object of type ET_Post which contains http status code, response, etc from the POST SOAP service
+    * @param 	array       $props 		Dictionary type array which may hold prepared stucture e.g. array('id' => '', 'key' => '')
     */	
-	public function post()
+	public function post($props=array())
 	{
 		$this->getCustomerKey();
 		$originalProps = $this->props;		
 		$overrideProps = array();
-		$fields = array();
+                if ($props) {
+                    $overrideProps = $props;
+                } else {
+                    $fields = array();
+
+                    foreach ($this->props as $key => $value){
+                            $fields[]  = array("Name" => $key, "Value" => $value);	
+                    }		
+                    $overrideProps['CustomerKey'] = $this->CustomerKey;
+                    $overrideProps['Properties'] = array("Property"=> $fields);
 		
-		foreach ($this->props as $key => $value){
-			$fields[]  = array("Name" => $key, "Value" => $value);	
-		}		
-		$overrideProps['CustomerKey'] = $this->CustomerKey;
-		$overrideProps['Properties'] = array("Property"=> $fields);
-		
+                }
 		$this->props = $overrideProps;		
 		$response = parent::post();		
 		$this->props = $originalProps;

--- a/src/ET_Get.php
+++ b/src/ET_Get.php
@@ -16,14 +16,13 @@ class ET_Get extends ET_Constructor
 	* @param    string      $objType 	Object name, e.g. "ImportDefinition", "DataExtension", etc
 	* @param 	array       $props 		Dictionary type array which may hold e.g. array('id' => '', 'key' => '')
 	* @param 	array    	$filter 	Dictionary type array which may hold e.g. array("Property"=>"", "SimpleOperator"=>"","Value"=>"")
-	* @param 	bool		$getSinceLastBatch 	Gets or sets a boolean value indicating whether to get since last batch. true if get since last batch; otherwise, false.
+	* @param 	array    	$retrieveRequest 	Dictionary type array which may hold e.g. array("ClientIDs"=>array("ID"=>123))
 	*/	
-	function __construct($authStub, $objType, $props, $filter, $getSinceLastBatch = false)
+	function __construct($authStub, $objType, $props, $filter, $retrieveRequest=array())
 	{
 		$authStub->refreshToken();
 		$rrm = array();
 		$request = array();
-		$retrieveRequest = array();
 		
 		// If Props is not sent then Info will be used to find all retrievable properties
 		if (is_null($props)){	
@@ -67,14 +66,9 @@ class ET_Get extends ET_Constructor
 				$retrieveRequest["Filter"] = new SoapVar($filter, SOAP_ENC_OBJECT, 'SimpleFilterPart', "http://exacttarget.com/wsdl/partnerAPI");
 			}
 		}
-		if ($getSinceLastBatch) {
-			$retrieveRequest["RetrieveAllSinceLastBatch"] = true;
-		}
-		
 		
 		$request["RetrieveRequest"] = $retrieveRequest;
 		$rrm["RetrieveRequestMsg"] = $request;
-		
 		$return = $authStub->__soapCall("Retrieve", $rrm, null, null , $out_header);
 		parent::__construct($return, $authStub->__getLastResponseHTTPCode());
 		

--- a/src/ET_GetSupport.php
+++ b/src/ET_GetSupport.php
@@ -14,11 +14,15 @@ class ET_GetSupport extends ET_BaseObject
     */
 	public function get()
 	{
-		$lastBatch = false;
-		if (property_exists($this,'getSinceLastBatch' )){
-			$lastBatch = $this->getSinceLastBatch;
+                $retrieveRequest=array();
+		if (property_exists($this,'retrieveRequest' )){
+			$retrieveRequest = $this->retrieveRequest;
 		}
-		$response = new ET_Get($this->authStub, $this->obj, $this->props, $this->filter, $lastBatch);
+		if (property_exists($this,'getSinceLastBatch')){
+			$retrieveRequest["RetrieveAllSinceLastBatch"] = $this->getSinceLastBatch;
+		}
+                
+		$response = new ET_Get($this->authStub, $this->obj, $this->props, $this->filter, $retrieveRequest);
 		$this->lastRequestID = $response->request_id;		
 		return $response;
 	}


### PR DESCRIPTION
In order to work correctly with DataExtensions when it's being created on the parent account, you need to pass <ClientIDs> also at the Get calls as well.

```xml
<RetrieveRequestMsg xmlns="http://exacttarget.com/wsdl/partnerAPI">	    
	<RetrieveRequest> 
		<ClientIDs>	
			<ClientID>1234567</ClientID>
		</ClientIDs>

<!-- ...snippet end...-->
```

In order to make this possible, we 
- exposed retrieveRequest to be able to pull the data 
- modified post() to accept custom arrays

final working examples are like this:

create DataExtensions with custom ClientID

```php
$postDRRow = new ET_DataExtension_Row();
$postDRRow->authStub = $this->soap_client;
$postDRRow->CustomerKey = $customerKey;
$objects = array(
    'Client' => array('ID' => $this->client_id),
);
foreach ($props as $key => $value) {
    $fields[] = array("Name" => $key, "Value" => $value);
}
$objects['CustomerKey'] = 'DataExtensionName';
$objects['Properties'] = array("Property" => $fields);

$res = $postDRRow->post($objects); /*<-- pass custom objects*/
```

and for retrieving custom DataExtensions 

```php
$getDERows = new ET_DataExtension_Row();
$getDERows->authStub = $this->soap_client;
$getDERows->retrieveRequest['ClientIDs'] = array('ID' => $this->client_id); /* <-- new exposed property*/
$getDERows->props = array(<edited attributes>'');
$getDERows->Name = $customerKey;
$getDERows->CustomerKey = $customerKey;

$res = $getDERows->get();
```