### PR TITLE
option to read from config. Fix php 7 issues

### DIFF
--- a/src/ET_CacheService.php
+++ b/src/ET_CacheService.php
@@ -16,7 +16,8 @@ class ET_CacheService
     public function get()
     {
         $now = time();
-        $data = ET_CacheService::$cachedSoapUrls[$this->_identifier];
+        $data = isset(ET_CacheService::$cachedSoapUrls[$this->_identifier]) ? ET_CacheService::$cachedSoapUrls[$this->_identifier] : null;
+
         if (!$data || !$data->expires || $data->expires < $now) {
             // remove expired data from the array
             unset(ET_CacheService::$cachedSoapUrls[$this->_identifier]);

--- a/src/ET_Client.php
+++ b/src/ET_Client.php
@@ -95,19 +95,24 @@ class ET_Client extends SoapClient
 	 * <i><b>proxyusername</b></i> - proxy server user name</br>
 	 * <i><b>proxypassword</b></i> - proxy server password</br>
 	 * <i><b>sslverifypeer</b></i> - Require verification of peer name</br>
+	 * @param boolean $readConfig Default true, read the config.php file if it exists.
+	 * @param string|null $configPath Read the config.php file from specific path.
 	 */
-	function __construct($getWSDL = false, $debug = false, $params = null) 
+	function __construct($getWSDL = false, $debug = false, $params = null, $readConfig = true, $configPath = null)
 	{
 		$tenantTokens = array();
 		$config = false;
 
 		$this->xmlLoc = 'ExactTargetWSDL.xml';
 
-		if (file_exists(realpath("config.php")))
-			$config = include 'config.php';
+		if ($readConfig) {
+			$configPath = $configPath ? $configPath : realpath("config.php");
+			if (file_exists($configPath)) {
+				$config = include 'config.php';
+			}
+		}
 
-		if ($config)
-		{
+		if ($config) {
 			$this->wsdlLoc = $config['defaultwsdl'];
 			$this->clientId = $config['clientid'];
 			$this->clientSecret = $config['clientsecret'];
@@ -155,7 +160,8 @@ class ET_Client extends SoapClient
 			if (array_key_exists('proxyusername', $config)){$this->proxyUserName = $config['proxyusername'];}
 			if (array_key_exists('proxypassword', $config)){$this->proxyPassword = $config['proxypassword'];}
 			if (array_key_exists('sslverifypeer', $config)){$this->sslVerifyPeer = $config['sslverifypeer'];}
-		} 
+		}
+
 		if ($params) 
 		{
 			if (array_key_exists('defaultwsdl', $params)){$this->wsdlLoc = $params['defaultwsdl'];}
@@ -308,6 +314,7 @@ class ET_Client extends SoapClient
 
 		parent::__setLocation($this->endpoint);
 	}
+
 	/**
 	 * Gets the refresh token using the authentication URL.
 	 *
@@ -611,7 +618,7 @@ class ET_Client extends SoapClient
 	public function getAuthToken($tenantKey = null) 
 	{
 		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}		
 		return isset($this->tenantTokens[$tenantKey]['authToken']) 
@@ -627,7 +634,7 @@ class ET_Client extends SoapClient
 	*/
 	function setAuthToken($tenantKey, $authToken, $authTokenExpiration) 
 	{
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}
 		$this->tenantTokens[$tenantKey]['authToken'] = $authToken;
@@ -642,7 +649,7 @@ class ET_Client extends SoapClient
 	function getAuthTokenExpiration($tenantKey) 
 	{
 		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}
 		return isset($this->tenantTokens[$tenantKey]['authTokenExpiration'])
@@ -658,7 +665,7 @@ class ET_Client extends SoapClient
 	function getInternalAuthToken($tenantKey) 
 	{
 		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;	
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}
 		return isset($this->tenantTokens[$tenantKey]['internalAuthToken'])
@@ -672,7 +679,7 @@ class ET_Client extends SoapClient
 	* @param string $internalAuthToken
 	*/
 	function setInternalAuthToken($tenantKey, $internalAuthToken) {
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}	
 		$this->tenantTokens[$tenantKey]['internalAuthToken'] = $internalAuthToken;
@@ -685,7 +692,7 @@ class ET_Client extends SoapClient
 	*/
 	function setRefreshToken($tenantKey, $refreshToken) 
 	{
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}	
 		$this->tenantTokens[$tenantKey]['refreshToken'] = $refreshToken;
@@ -700,7 +707,7 @@ class ET_Client extends SoapClient
 	public function getRefreshToken($tenantKey)
 	{
 		$tenantKey = $tenantKey == null ? $this->tenantKey : $tenantKey;	
-		if ($this->tenantTokens[$tenantKey] == null) {
+		if (!isset($this->tenantTokens[$tenantKey]) || $this->tenantTokens[$tenantKey] == null) {
 			$this->tenantTokens[$tenantKey] = array();
 		}
 		return isset($this->tenantTokens[$tenantKey]['refreshToken']) 

--- a/src/ET_Client.php
+++ b/src/ET_Client.php
@@ -108,7 +108,7 @@ class ET_Client extends SoapClient
 		if ($readConfig) {
 			$configPath = $configPath ? $configPath : realpath("config.php");
 			if (file_exists($configPath)) {
-				$config = include 'config.php';
+				$config = include $configPath;
 			}
 		}
 

--- a/src/ET_Client.php
+++ b/src/ET_Client.php
@@ -531,11 +531,10 @@ class ET_Client extends SoapClient
 		$doc = new DOMDocument();
 		$doc->loadXML($request);
 
-        if($this->useOAuth2Authentication === true){
+        if($this->useOAuth2Authentication === true) {
             $this->addOAuth($doc, $this->getAuthToken($this->tenantKey));
 			$content = $doc->saveXML();
-		}
-		else{
+		} else {
             $objWSSE = new WSSESoap($doc);
             $objWSSE->addUserToken("*", "*", FALSE);
 			$this->addOAuth($doc, $this->getInternalAuthToken($this->tenantKey));
@@ -543,9 +542,16 @@ class ET_Client extends SoapClient
 			$content = $objWSSE->saveXML();
 		}
 
-		if ($this->debugSOAP){
+		if ($this->debugSOAP) {
 			error_log ('FuelSDK SOAP Request: ');
-			error_log (str_replace($this->getInternalAuthToken($this->tenantKey),"REMOVED",$content));
+			error_log (str_replace($this->getInternalAuthToken($this->tenantKey), "REMOVED", $content));
+		}
+
+		if ('Retrieve' === $saction && false !== strpos($content, '<ns1:ObjectType>EmailSendDefinition</ns1:ObjectType>')) {
+			$content = str_replace('<ns1:Properties>DeliveryProfile.CusomterKey</ns1:Properties>', '', $content);
+			$content = str_replace('<ns1:Properties>DeliveryProfile.HeaderContentArea.ID</ns1:Properties>', '', $content);
+			$content = str_replace('<ns1:Properties>DeliveryProfile.FooterContentArea.ID</ns1:Properties>', '', $content);
+			$content = str_replace('<ns1:Properties>SendWindowCloses</ns1:Properties>', '', $content);
 		}
 		
 		$headers = array("Content-Type: text/xml","SOAPAction: ".$saction, "User-Agent: ".ET_Util::getSDKVersion());

--- a/src/ET_Client.php
+++ b/src/ET_Client.php
@@ -3,7 +3,7 @@
 namespace FuelSdk;
 
 use \RobRichards\WsePhp\WSSESoap;
-use \Firebase\JWT;
+use \Firebase\JWT\JWT;
 
 use \Datetime;
 use \SoapClient;


### PR DESCRIPTION
Fixes:
- #144 
- #159
- 

To read the config file from a custom path:
```php
$myclient = new ET_Client(true, false, null, true, '/path/to/config.php');
```

To ignore config file:
```php
$params = array(...);
$myclient = new ET_Client(true, false, $params, false);
```

I can submit another PR to optimize and remove duplicate code from ET_Client constructor. Merging **$params** with **$config** should do the trick.