### PR TITLE
PHP 8: HOTFIX Deprecated function: trim(): Passing null to parameter of type string is deprecated.

### DIFF
--- a/src/ET_Client.php
+++ b/src/ET_Client.php
@@ -386,10 +386,10 @@ class ET_Client extends SoapClient
             $payload->grant_type = 'client_credentials';
 		}
 
-		if (!empty(trim($this->accountId))){
+		if (!empty(trim($this->accountId ?? ''))){
             $payload->account_id = $this->accountId;
 		}
-		if (!empty(trim($this->scope))){
+		if (!empty(trim($this->scope ?? ''))){
             $payload->scope = $this->scope;
 		}
 


### PR DESCRIPTION
**See Bug reported here:**

- #172 